### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if SETUPTOOLS_COMMANDS.intersection(sys.argv):
         include_package_data=True,
         install_requires=[
             'numpy >= {0}'.format(NUMPY_MIN_VERSION),
-            'Cython >=0.29.13,<1.0.0',
+            'Cython >=0.29.13, <1.0.0',
         ],
         extras_require={
             'alldeps': (


### PR DESCRIPTION
Fixes lap setup:

```
  Processing ./.venv/src/lap
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error

    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [6 lines of output]
        /home/fernando/projects/loggi/py-shared/libs/allocation_offers/.venv/src/lap/setup.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/l
atest/pkg_resources.html
          from pkg_resources import parse_version
        Partial import of lap during the build process.
        error in lap setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version sp
ecifier)
            Cython >=0.29.13<1.0.0
                   ~~~~~~~~~^
```